### PR TITLE
[2024.07.03] feat/#8-like-menu >> 좋아요한 메뉴 목록 조회 기능 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,12 @@ dependencies {
     compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
     runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
+    //QueryDSL 적용을 위한 의존성 (SpringBoot3.0 부터는 jakarta 사용해야함)
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+    annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sparta/greeypeople/common/JpaConfig.java
+++ b/src/main/java/com/sparta/greeypeople/common/JpaConfig.java
@@ -1,0 +1,19 @@
+package com.sparta.greeypeople.common;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JpaConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/sparta/greeypeople/menu/controller/MenuController.java
+++ b/src/main/java/com/sparta/greeypeople/menu/controller/MenuController.java
@@ -1,14 +1,18 @@
 package com.sparta.greeypeople.menu.controller;
 
+import com.sparta.greeypeople.auth.security.UserDetailsImpl;
 import com.sparta.greeypeople.common.DataCommonResponse;
 import com.sparta.greeypeople.menu.dto.response.AdminMenuResponseDto;
+import com.sparta.greeypeople.menu.dto.response.MenuResponseDto;
 import com.sparta.greeypeople.menu.service.MenuService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -31,6 +35,14 @@ public class MenuController {
         DataCommonResponse<List<AdminMenuResponseDto>> response = new DataCommonResponse<>(200,
             "가게 전체 메뉴 조회 성공", storeMenu);
         return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @GetMapping("/stores/menus/likes")
+    public ResponseEntity<DataCommonResponse<List<MenuResponseDto>>> getLikesMenus(@AuthenticationPrincipal UserDetailsImpl userDetails,
+        @RequestParam("page") int page) {
+        List<MenuResponseDto> menus = menuService.getLikesMenusWithPageAndSortDesc(userDetails.getUser(), page, 5);
+        DataCommonResponse<List<MenuResponseDto>> response = new DataCommonResponse<>(HttpStatus.OK.value(), "좋아요한 메뉴 목록 최신순 조회 완료", menus);
+        return ResponseEntity.ok().body(response);
     }
 
 }

--- a/src/main/java/com/sparta/greeypeople/menu/dto/response/MenuResponseDto.java
+++ b/src/main/java/com/sparta/greeypeople/menu/dto/response/MenuResponseDto.java
@@ -1,5 +1,6 @@
 package com.sparta.greeypeople.menu.dto.response;
 
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,6 +12,7 @@ public class MenuResponseDto {
     private String menuName;
     private int price;
 
+    @Builder
     public MenuResponseDto(Long storeId, String menuName, Integer price) {
         this.storeId = storeId;
         this.menuName = menuName;

--- a/src/main/java/com/sparta/greeypeople/menu/repository/MenuRepository.java
+++ b/src/main/java/com/sparta/greeypeople/menu/repository/MenuRepository.java
@@ -5,9 +5,11 @@ import com.sparta.greeypeople.menu.entity.Menu;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.RepositoryDefinition;
 import org.springframework.data.repository.query.Param;
 
-public interface MenuRepository extends JpaRepository<Menu, Long> {
+@RepositoryDefinition(domainClass = Menu.class, idClass = Long.class)
+public interface MenuRepository extends JpaRepository<Menu, Long>, MenuRepositoryQuery {
     List<Menu> findByStoreId(Long storeId);
 
     @Query("SELECT new com.sparta.greeypeople.menu.dto.response.MenuResponseDto(m.store.id, m.menuName, m.price) " +

--- a/src/main/java/com/sparta/greeypeople/menu/repository/MenuRepositoryQuery.java
+++ b/src/main/java/com/sparta/greeypeople/menu/repository/MenuRepositoryQuery.java
@@ -1,0 +1,9 @@
+package com.sparta.greeypeople.menu.repository;
+
+import com.sparta.greeypeople.menu.entity.Menu;
+import com.sparta.greeypeople.user.entity.User;
+import java.util.List;
+
+public interface MenuRepositoryQuery {
+    List<Menu> getLikesMenusWithPageAndSortDesc(User user, long offset, int pageSize);
+}

--- a/src/main/java/com/sparta/greeypeople/menu/repository/MenuRepositoryQueryImpl.java
+++ b/src/main/java/com/sparta/greeypeople/menu/repository/MenuRepositoryQueryImpl.java
@@ -1,0 +1,33 @@
+package com.sparta.greeypeople.menu.repository;
+
+import static com.sparta.greeypeople.like.entity.QMenuLikes.menuLikes;
+import static com.sparta.greeypeople.menu.entity.QMenu.menu;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.greeypeople.menu.entity.Menu;
+import com.sparta.greeypeople.user.entity.User;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MenuRepositoryQueryImpl implements MenuRepositoryQuery {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<Menu> getLikesMenusWithPageAndSortDesc(User user, long offset, int pageSize) {
+        OrderSpecifier<?> orderSpecifier = new OrderSpecifier<>(Order.DESC, menuLikes.createdAt);
+
+        return jpaQueryFactory.selectFrom(menu)
+            .join(menuLikes).on(menuLikes.menu.eq(menu))
+            .where(menuLikes.user.eq(user))
+            .offset(offset)
+            .limit(pageSize)
+            .orderBy(orderSpecifier)
+            .fetch();
+    }
+}

--- a/src/main/java/com/sparta/greeypeople/menu/service/MenuService.java
+++ b/src/main/java/com/sparta/greeypeople/menu/service/MenuService.java
@@ -2,14 +2,19 @@ package com.sparta.greeypeople.menu.service;
 
 import com.sparta.greeypeople.exception.DataNotFoundException;
 import com.sparta.greeypeople.menu.dto.response.AdminMenuResponseDto;
+import com.sparta.greeypeople.menu.dto.response.MenuResponseDto;
 import com.sparta.greeypeople.menu.entity.Menu;
 import com.sparta.greeypeople.menu.repository.MenuRepository;
 import com.sparta.greeypeople.store.entity.Store;
 import com.sparta.greeypeople.store.repository.StoreRepository;
+import com.sparta.greeypeople.user.entity.User;
+import com.sparta.greeypeople.user.repository.UserRepository;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -17,6 +22,7 @@ public class MenuService {
 
     private final StoreRepository storeRepository;
     private final MenuRepository menuRepository;
+    private final UserRepository userRepository;
 
     public List<AdminMenuResponseDto> getStoreMenu(Long storeId) {
         findStore(storeId);
@@ -30,4 +36,23 @@ public class MenuService {
             () -> new DataNotFoundException("조회된 가게의 정보가 없습니다.")
         );
     }
+
+    @Transactional(readOnly = true)
+    public List<MenuResponseDto> getLikesMenusWithPageAndSortDesc(User user, int page, int size) {
+        User validatedUser = userRepository.findById(user.getId()).orElseThrow(() ->
+            new DataNotFoundException("해당 사용자가 존재하지 않습니다."));
+
+        PageRequest pageRequest = PageRequest.of(page, size);
+
+        return menuRepository.getLikesMenusWithPageAndSortDesc(validatedUser, pageRequest.getOffset(), pageRequest.getPageSize())
+            .stream()
+            .map(m ->
+                MenuResponseDto.builder()
+                    .storeId(m.getStore().getId())
+                    .menuName(m.getMenuName())
+                    .price(m.getPrice())
+                    .build())
+            .collect(Collectors.toList());
+    }
+
 }


### PR DESCRIPTION
## 📑 작업 내용

> - 좋아요한 메뉴 목록 조회 기능을 구현
> 1. 좋아요 등록 최신순 정렬
> 2. 5개씩 페이지네이션
