### PR TITLE
[2024.07.03] feat/#8-like-menu >> 사용자가 등록한 메뉴 좋아요 개수 조회 메서드 생성

### DIFF
--- a/src/main/java/com/sparta/greeypeople/like/repository/MenuLikesRepository.java
+++ b/src/main/java/com/sparta/greeypeople/like/repository/MenuLikesRepository.java
@@ -4,11 +4,10 @@ import com.sparta.greeypeople.like.entity.MenuLikes;
 import com.sparta.greeypeople.menu.entity.Menu;
 import com.sparta.greeypeople.user.entity.User;
 import java.util.Optional;
-
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
+import org.springframework.data.repository.RepositoryDefinition;
 
-@Repository
-public interface MenuLikesRepository extends JpaRepository<MenuLikes, Long> {
+@RepositoryDefinition(domainClass = MenuLikes.class, idClass = Long.class)
+public interface MenuLikesRepository extends JpaRepository<MenuLikes, Long>, MenuLikesRepositoryQuery {
 	Optional<MenuLikes> findByUserAndMenu(User foundUser, Menu foundMenu);
 }

--- a/src/main/java/com/sparta/greeypeople/like/repository/MenuLikesRepositoryQuery.java
+++ b/src/main/java/com/sparta/greeypeople/like/repository/MenuLikesRepositoryQuery.java
@@ -1,0 +1,5 @@
+package com.sparta.greeypeople.like.repository;
+
+public interface MenuLikesRepositoryQuery {
+    long countMenuLikesByUserId(Long userId);
+}

--- a/src/main/java/com/sparta/greeypeople/like/repository/MenuLikesRepositoryQueryImpl.java
+++ b/src/main/java/com/sparta/greeypeople/like/repository/MenuLikesRepositoryQueryImpl.java
@@ -1,0 +1,28 @@
+package com.sparta.greeypeople.like.repository;
+
+import static com.sparta.greeypeople.like.entity.QMenuLikes.menuLikes;
+
+import com.querydsl.core.types.dsl.Wildcard;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MenuLikesRepositoryQueryImpl implements MenuLikesRepositoryQuery {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public long countMenuLikesByUserId(Long userId) {
+        Long count =  jpaQueryFactory
+            .select(Wildcard.count)
+            .from(menuLikes)
+            .where(menuLikes.user.id.eq(userId))
+            .fetchOne();  //레코드의 개수를 세는 쿼리의 경우 단일 숫자 값을 반환하므로 fetchOne 사용
+
+        // fetchOne()은 쿼리 결과가 없을 경우 null을 반환하므로 Optional을 사용하여 안전하게 처리
+        return Optional.ofNullable(count).orElse(0L);
+    }
+}


### PR DESCRIPTION
## 📑 작업 내용

> - 해당 사용자가 등록한 메뉴 좋아요의 개수를 조회하는 쿼리 포함

